### PR TITLE
Custom commit SHA for tag can be specified with "from-commit-sha"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
           # yamllint disable-line rule:line-length
           release-name-extension: '-rc${{ steps.count.outputs.rc_number }}.dev${{ github.event.number }}+${{ github.sha }}'
           draft-release: true
-          prerelease: false
+          prerelease: true
       - name: Report action output
         # yamllint disable rule:line-length
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,48 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Count run number
+        id: count
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setFailed("This workflow must be triggered by a pull request.");
+              return;
+            }
+
+            const pr_number = pr.number;
+            const workflow_name = context.workflow;
+            const branch_name = pr.head.ref;
+            const event_match = "pull_request";
+            console.log("PR Number: " + pr_number);
+            console.log("Workflow name: " + workflow_name);
+            console.log("Branch name: " + branch_name);
+
+            if (!pr_number) {
+              console.log("No pull request number found in context.");
+              core.setOutput("count", 0);
+              return;
+            }
+
+            const runs = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: event_match,
+              branch: branch_name,
+              per_page: 100
+            });
+
+            const filtered = runs.data.workflow_runs.filter(run =>
+              run.name === workflow_name &&
+              run.event === event_match &&
+              run.pull_requests?.some(p => p.number === pr_number)
+            );
+            console.log("Matches for filters aka runs: " + filtered.length);
+
+            const count = filtered.length > 0 ? filtered.length : 1;
+            core.setOutput("rc_number", count);
       - name: Test action with default inputs
         uses: brainelectronics/changelog-based-release@main
         with:
@@ -30,7 +72,7 @@ jobs:
           tag-name-extension: '+${{ github.sha }}'
           release-name-prefix: 'Test v'
           # yamllint disable-line rule:line-length
-          release-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}+${{ github.sha }}'
+          release-name-extension: '-rc${{ steps.count.outputs.rc_number }}.dev${{ github.event.number }}+${{ github.sha }}'
           draft-release: true
           prerelease: false
       - name: Report action output

--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,10 @@ inputs:
     description: 'Is this a Prerelease'
     required: true
     default: false
+  from-commit-sha:
+    description: 'Commit SHA to create tag on'
+    required: false
+    default: ${{ github.sha }}
 
 outputs:
   latest-description:
@@ -62,6 +66,9 @@ runs:
     - name: Print changelog2version version
       run: changelog2version --version
       shell: bash
+    - name: Log commit SHA
+      run: echo ${{ github.sha }}
+      shell: bash
     - name: Parse changelog
       id: parse-changelog
       # yamllint disable rule:line-length
@@ -82,6 +89,7 @@ runs:
         # yamllint disable-line rule:line-length
         name: ${{ inputs.tag-name-prefix }}${{ steps.parse-changelog.outputs.LATEST_VERSION }}${{ inputs.release-name-extension }}
         body: ${{ steps.parse-changelog.outputs.LATEST_DESCRIPTION }}
+        target_commitish: ${{ inputs.from-commit-sha }}
         draft: ${{ inputs.draft-release }}
         prerelease: ${{ inputs.prerelease }}
         token: ${{ inputs.github-token }}

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 ### Fixed
 - Always create the release from the checked out commit SHA
 - Set correct number for the rc metadata
+- Set pull request builds of this repo always as pre-release
 
 ## [1.1.0] - 2026-04-06
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 
 ### Fixed
 - Always create the release from the checked out commit SHA
+- Set correct number for the rc metadata
 
 ## [1.1.0] - 2026-04-06
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,13 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [1.2.0] - 2026-05-04
+### Added
+- Custom commit SHA for tag can be specified with `from-commit-sha`
+
+### Fixed
+- Always create the release from the checked out commit SHA
+
 ## [1.1.0] - 2026-04-06
 ### Added
 - `.pre-commit-config` with `yamllint`
@@ -47,8 +54,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - The above `0.1.0` section is required due to a bug in `changelog2version`
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/changelog-based-release/compare/1.1.0...main
+[Unreleased]: https://github.com/brainelectronics/changelog-based-release/compare/1.2.0...main
 
+[1.2.0]: https://github.com/brainelectronics/changelog-based-release/tree/1.2.0
 [1.1.0]: https://github.com/brainelectronics/changelog-based-release/tree/1.1.0
 [1.0.0]: https://github.com/brainelectronics/changelog-based-release/tree/1.0.0
 [0.1.0]: https://github.com/brainelectronics/changelog-based-release/tree/0.1.0


### PR DESCRIPTION
### Added
- Custom commit SHA for tag can be specified with `from-commit-sha`

### Fixed
- Always create the release from the checked out commit SHA
 - Set correct number for the rc metadata
- Set pull request builds of this repo always as pre-release