### PR TITLE
Install changelog2version instead of requirements txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ jobs:
     name: Release
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: 'Create changelog based release'
         uses: brainelectronics/changelog-based-release@v1
 ```
@@ -102,11 +102,12 @@ The following are optional as `step.with` keys
 | `release-name-extension`  | String  | Extension of release name after extracted x.y.z from changelog, e.g. `-rc` to get `1.2.3-rc`. Defaults to `-rc${{ github.run_number }}.dev${{ github.event.number }}` e.g. `1.2.3-rc21.dev`                           |
 | `draft-release`           | Boolean | Indicator of whether or not this release is a draft. Defaults to `false`                                                                                                                                              |
 | `prerelease`              | Boolean | Indicator of whether or not is a prerelease. Defaults to `false`                                                                                                                                                      |
+| `from-commit-sha`         | String  | Commit SHA to create tag on. Defaults to `${{ github.head_ref }}`                                                                                                                                                      |
 
 ```yaml
 steps:
   - name: Checkout
-    uses: actions/checkout@v3
+    uses: actions/checkout@v6
   - name: 'Create changelog based release'
     uses: brainelectronics/changelog-based-release@v1
     with:

--- a/action.yaml
+++ b/action.yaml
@@ -59,7 +59,7 @@ runs:
       with:
         python-version: '3.10'
     - name: Install required packages
-      run: pip install -r requirements.txt
+      run: pip install "changelog2version>=0.12.1,<1"
       shell: bash
     - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
       shell: bash

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,11 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [1.2.3] - 2026-05-04
+### Fixed
+- Install `changelog2version` instead of relying on a valid `requirements.txt` file
+- Add missing documentation for `from-commit-sha`
+
 ## [1.2.2] - 2026-05-04
 ### Fixed
 - Log output while reporting commit to tag
@@ -64,8 +69,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - The above `0.1.0` section is required due to a bug in `changelog2version`
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/changelog-based-release/compare/1.2.2...main
+[Unreleased]: https://github.com/brainelectronics/changelog-based-release/compare/1.2.3...main
 
+[1.2.3]: https://github.com/brainelectronics/changelog-based-release/tree/1.2.3
 [1.2.2]: https://github.com/brainelectronics/changelog-based-release/tree/1.2.2
 [1.2.1]: https://github.com/brainelectronics/changelog-based-release/tree/1.2.1
 [1.2.0]: https://github.com/brainelectronics/changelog-based-release/tree/1.2.0


### PR DESCRIPTION
### Fixed
- Install `changelog2version` instead of relying on a valid `requirements.txt` file
- Add missing documentation for `from-commit-sha`